### PR TITLE
Upgrade java generator to `0.3.5`

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -10,4 +10,4 @@ groups:
           username: ${FERN_MAVEN_USERNAME}
           password: ${FERN_MAVEN_TOKEN}
         github:
-          repository: fern-suger/suger-java 
+          repository: sugerio/suger-sdk-java 

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -3,7 +3,7 @@ groups:
   external:
     generators:
       - name: fernapi/fern-java-sdk
-        version: 0.3.4
+        version: 0.3.5
         output:
           location: maven
           coordinate: io.github.fern-api:suger


### PR DESCRIPTION
0.3.5 of the java generator contains a fix (https://github.com/fern-api/fern-java/pull/269) to remove unnecessary slashes in the http url paths.